### PR TITLE
#9 feat : create reformer certification register api

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -17,3 +17,11 @@ class Style(admin.ModelAdmin):
 @admin.register(models.Material)
 class Material(admin.ModelAdmin):
     pass
+
+@admin.register(models.ReformerProfile)
+class ReformerProfile(admin.ModelAdmin):
+    pass
+
+@admin.register(models.Certification)
+class Certification(admin.ModelAdmin):
+    pass

--- a/users/services.py
+++ b/users/services.py
@@ -20,8 +20,9 @@ from rest_framework_simplejwt.exceptions import InvalidToken
 from rest_framework_jwt.settings import api_settings
 from django.core.files.images import ImageFile
 from django.core.files.uploadedfile import InMemoryUploadedFile
-
-from users.models import User
+from django.core.files import File
+from django.core.files.base import ContentFile
+from users.models import User, ReformerProfile, Certification
 from users.selectors import UserSelector
 # from core.exceptions import ApplicationError
 
@@ -171,14 +172,19 @@ class UserService:
     def reformer_profile_register(self,user:User, nickname:str, market_name:str,market_intro:str,links:str,area:str,
         work_style:list[str],special_material:list[str]):
         
-        user.nickname=nickname
-        user.market_name=market_name
-        user.market_intro=market_intro
-        user.links=links
-        user.area=area
-        
-        user.work_style.set(work_style)
-        user.special_material.set(special_material)
-        user.full_clean()
-        user.save()
-        
+        reformer=ReformerProfile(user=user,nickname=nickname,market_name=market_name, market_intro=market_intro,
+                                 links=links,)
+        reformer.save()
+        reformer.work_style.set(work_style)
+        reformer.special_material.set(special_material)
+    #reformer 학력 파일 등 파일 필드 서버로 추가 기능 필요(현재 로컬에 저장됨)
+    
+    def certification_register(self,profile:ReformerProfile,name:str,issuing_authority:str,issue_date:datetime,proof_document:InMemoryUploadedFile):
+        certification=Certification(profile=profile,name=name,issuing_authority=issuing_authority,issue_date=issue_date)
+
+        ext = proof_document.name.split(".")[-1]
+        file_path = 'users/profile/certification/{}{}'.format(str(time.time())+str(uuid.uuid4().hex), ext)
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        #proof_document = File(io.BytesIO(proof_document.read()), name=file_path)
+        certification.proof_document.save(file_path, ContentFile(proof_document.read()), save=False)
+        certification.save()

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenRefreshView, TokenVerifyView
-from .views import UserSignUpApi,UserLoginApi,ReformerProfileApi
+from .views import UserSignUpApi,UserLoginApi,ReformerProfileApi,CertificationCreateApi
 app_name = "users"
 
 urlpatterns =[
@@ -10,4 +10,6 @@ urlpatterns =[
     path('login/', UserLoginApi.as_view(), name = 'login'),
     path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('profile_register/',ReformerProfileApi.as_view(),name='profile_register'),   
+    path('certification_register/',CertificationCreateApi.as_view(),name='certification'),
+
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -182,7 +182,7 @@ class ReformerProfileApi(APIView):
     permission_classes = (AllowAny,)
     
     class ReformerProfileInputSerializer(serializers.Serializer):
-        nickname= serializers.CharField()
+        nickname=serializers.CharField()
         market_name=serializers.CharField()
         market_intro=serializers.CharField()
         links=serializers.CharField()
@@ -191,7 +191,7 @@ class ReformerProfileApi(APIView):
         work_style=serializers.CharField()
         special_material=serializers.CharField()
     
-    def put(self,request):
+    def post(self,request):
         serializer = self.ReformerProfileInputSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data=serializer.validated_data
@@ -212,3 +212,32 @@ class ReformerProfileApi(APIView):
         return Response({
             'status':'success',
         },status=status.HTTP_200_OK)
+        
+class CertificationCreateApi(APIView):
+    permission_classes=(AllowAny,)
+    
+    class CertificationCreateInputSerializer(serializers.Serializer):
+        name = serializers.CharField()
+        issuing_authority = serializers.CharField()
+        issue_date = serializers.DateField()
+        proof_document = serializers.FileField()
+        
+    def post(self,request):
+        input_serializer = self.CertificationCreateInputSerializer(data=request.data)
+        input_serializer.is_valid(raise_exception=True)
+        data = input_serializer.validated_data
+        
+        service=UserService()
+        
+        service.certification_register(
+            profile=request.user.reformer_profile,
+            name=data.get('name'),
+            issuing_authority=data.get('issuing_authority'),
+            issue_date=data.get('issue_date'),
+            proof_document=data.get('proof_document'),
+        )
+        
+        return Response({
+            'status':'success',
+        },status=status.HTTP_200_OK)
+        


### PR DESCRIPTION
### reformer 경력 등록 api 작성
- reformer certification proof document는 로컬 내의 users/profile/certification 경로에 저장하도록 임시 설정
- 후에 서버와 연동 필요